### PR TITLE
Error with typdef / struct definition in same statement

### DIFF
--- a/G-Structs-Unions/structs-unions.md
+++ b/G-Structs-Unions/structs-unions.md
@@ -74,9 +74,9 @@ directly a member of its own type). This is particular useful for data
 structures like trees.
 
 ```c
-typedef struct {
+typedef struct Node_t {
   void *value;
-  Node *parent;
+  struct Node_t *parent;
 } Node;
 
 Node root, child1, child2, child3, child4;
@@ -90,6 +90,12 @@ Bad:
 
 ```c
 /* this won't work */
+typedef struct {
+  void *value;
+  Node *parent;
+} Node;
+
+/* neither will this */
 struct {
     void *value;
     Node parent;


### PR DESCRIPTION
That means you can't start using `Node` until after the semicolon, so you need some intermediate type to be able to reference the struct itself if you want to do it all in one statement.

Alternatively, you can define the struct and typedef in separate statement.  (If you do it correctly, order doesn't matter).

```c
struct Node_t {
    void *value;
    struct Node_t *parent;
};

typedef struct Node_t Node;
```

or

```c
typedef struct Node_t Node;

struct Node_t {
    void *value;
    Node *parent;
};
```