### PR TITLE
removing implicit .c/.o file dependencies

### DIFF
--- a/B-Makefiles/practice/p1-solutions/Makefile-2
+++ b/B-Makefiles/practice/p1-solutions/Makefile-2
@@ -6,13 +6,13 @@ MAIN = main
 .PHONY: default
 default: all run
 
-$(MAIN): main.o ops.o opsprinter.o
+$(MAIN): ops.o opsprinter.o
 
-main.o: main.c ops.h
+main.o: ops.h
 
-ops.o: ops.c ops.h opsprinter.h
+ops.o: ops.h opsprinter.h
 
-opsprinter.o: opsprinter.c opsprinter.h
+opsprinter.o: opsprinter.h
 
 .PHONY: all
 all: clean main


### PR DESCRIPTION
Made `Makefile-2` even shorter by removing implied linking/compiling rules:

* `$(MAIN)` --> `main.o` is implied
* `main.o` --> `main.c` is implied
* `ops.o` --> `ops.c` is implied
* `opsprinter.o` --> `opsprinter.c` is implied