### PR TITLE
Fix reversed binary/unary operator preference in midsemester-review.md

### DIFF
--- a/midsemester-review.md
+++ b/midsemester-review.md
@@ -440,7 +440,7 @@ function.
 
 ## Order of Operations ##
 
-Binary Operators, Increasing Order of Precedence:
+Binary Operators, Decreasing Order of Precedence (i.e. `< > <= =>` have highest preference, `,` has lowest)
 
   - < > <= =>
   - + -
@@ -454,7 +454,7 @@ Binary Operators, Increasing Order of Precedence:
   - += -= *= /= <<= >>= 7= ^= |= %= >>= =
   - ,
 
-Unary Operators, Increasing Order of Precedence:
+Unary Operators, Decreasing Order of Precedence (first is highest preference, second is lowest)
 
   - (expression), [],  ->,  .
   - !, ~, ++, --, (type), sizeof, +,  -,  *,  &,   (right to left)


### PR DESCRIPTION
Note says that the operators are listed in increasing order of preference, whereas they really should be in decreasing order.

Cross-checked preference order against http://en.cppreference.com/w/c/language/operator_precedence.