### PR TITLE
[D-Bits] Be more specific about how right-shifts work

### DIFF
--- a/D-Bits-Binary-C-Basics/bits-binary-and-c-basics.md
+++ b/D-Bits-Binary-C-Basics/bits-binary-and-c-basics.md
@@ -90,8 +90,12 @@ complement on its operatand by flipping each bit.
 
 The bitwise shift operators, `<<` and `>>`, shift their left operand by the 
 number of digits specified by the right operand. Left shifting always fills 
-vacated bits by zero. Right shifting varies from machine to machine and whether 
-or not we're talking unsigned or signed.
+vacated bits by zero.
+
+Right shifting depends on whether we're dealing with signed or unsigned numbers.
+Unsigned numbers and positive signed numbers fill vacated bits with zero.
+Right-shifting negative signed numbers can produce varying results depending
+on the machine and compiler.
 
 ```
 int x = 2;  // 000010 in binary


### PR DESCRIPTION
Right-shifts are defined by the standard for unsigned and positive
signed numbers. From the C11 standard (section 6.5.7):

>The result of E1 >> E2 is E1 right-shifted E2 bit positions. If E1
>has an unsigned type or if E1 has a signed type and a nonnegative
>value, the value of the result is the integral part of the quotient
>of (E1 / 2^(E2)). If E1 has a signed type and a negative value, the
>resulting value is implementation-defined.