### PR TITLE
[K-File-IO] Fix types in example on size_t arithmetic pitfalls

### DIFF
--- a/K-File-IO/file-io.md
+++ b/K-File-IO/file-io.md
@@ -126,7 +126,7 @@ that it's an unsigned integer type. This means it works like an integer but
 ```c
 size_t x = 5;
 size_t y = 3;
-int z = x + y;
+size_t z = x + y;
 ```
 
 The following is not (and wouldn't be a good idea even if the value was
@@ -135,7 +135,7 @@ positive):
 ```c
 size_t x = 5;
 size_t y = 3;
-int z = y - x;
+size_t z = y - x;
 ```
 
 Other than that you can treat `size_t` as any other integer type.


### PR DESCRIPTION
size_t is a 64-bit integer on CLAC as opposed to a 32-bit int, so the
 loss of precision when using size_t arithmetic in an int didn't make
 sense anyway.

 Resolves #90