### PR TITLE
Corrected assert statements regarding character value comparisons

### DIFF
--- a/D-Bits-Binary-C-Basics/c-basics.md
+++ b/D-Bits-Binary-C-Basics/c-basics.md
@@ -294,8 +294,8 @@ So, consider the following:
     char c = '\0';
     char d = '\x0';
 
-    assert(a == b);
-    assert(a != c);
+    assert(a != b);
+    assert(a == c);
     assert(a == d);
 
 `char` literals can be added and subtracted just like any other number,


### PR DESCRIPTION
The previous assert statements would fail if they were run. As it is currently written, the "consider the following" seems to imply that the assert will be successful. If they were intended to be incorrect, then it is not made clear in the file (which can be changed). I instead opted to correct the statements.